### PR TITLE
No se necesita mas el repo uqbar-wiki

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,20 +26,6 @@
 		<tag>HEAD</tag>
 	</scm>
 
-	<repositories>
-		<repository>
-			<id>uqbar-wiki.org-releases</id>
-			<name>uqbar-wiki.org-releases</name>
-			<url>http://uqbar-wiki.org/mvn/releases</url>
-		</repository>
-		<repository>
-			<snapshots />
-			<id>uqbar-wiki.org-snapshots</id>
-			<name>uqbar-wiki.org-snapshots</name>
-			<url>http://uqbar-wiki.org/mvn/snapshots</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<!-- UQBAR -->
 		<dependency>


### PR DESCRIPTION
Luego del deploy que hizo @tesonep de [uqbar-class-descriptor](http://search.maven.org/#artifactdetails%7Corg.uqbar-project%7Cuqbar-class-descriptor%7C1.3.2%7Cjar), esto ya no hace falta.
